### PR TITLE
code cleanup and several fixes and additions

### DIFF
--- a/calibredb-core.el
+++ b/calibredb-core.el
@@ -103,9 +103,9 @@
   :type 'file
   :group 'calibredb)
 
-(defcustom calibredb-fetch-metadata-source-alist '(( "Google" ) ( "Amazon.com" ))
+(defcustom calibredb-fetch-metadata-source-list '("Google" "Amazon.com")
   "Source alist used to fetch ebook metadata."
-  :type 'alist
+  :type 'sexp
   :group 'calibredb)
 
 (defcustom calibredb-sql-separator "\3"

--- a/calibredb-core.el
+++ b/calibredb-core.el
@@ -83,6 +83,16 @@
   :type 'file
   :group 'calibredb)
 
+(defcustom calibre-debug-program
+  (cond
+   ((eq system-type 'darwin)
+    "/Applications/calibre.app/Contents/MacOS/calibre-debug")
+   (t
+    "calibre-debug"))
+  "Executable for calibredb-debug which is used for author_sort algorithm."
+  :type 'file
+  :group 'calibredb)
+
 (defcustom calibredb-fetch-metadata-program
   (cond
    ((eq system-type 'darwin)

--- a/calibredb-utils.el
+++ b/calibredb-utils.el
@@ -512,8 +512,9 @@ the outer alist (nil instead of (SOURCE RESULTS))."
          (title (if isbn ""
                   (read-string "Title: " title)))
          (isbn (if isbn (read-string "ISBN: " isbn)
-                 nil))
-         (sources calibredb-fetch-metadata-source-list)
+                 nil)))
+    (message "Fetching metadata from sources... may take a few seconds")
+    (let* ((sources calibredb-fetch-metadata-source-list)
          (results (mapcar
                    (lambda (source)
                      (let* ((md (shell-command-to-string
@@ -553,7 +554,7 @@ the outer alist (nil instead of (SOURCE RESULTS))."
     (if (remove nil results)
         (remove nil results)
       nil)
-    ))
+    )))
 
 (defun calibredb-select-and-set-cover (results &optional cover)
   (when (get-buffer (calibredb-show--buffer-name (calibredb-find-candidate-at-point)))

--- a/calibredb-utils.el
+++ b/calibredb-utils.el
@@ -539,7 +539,9 @@ the outer alist (nil instead of (SOURCE RESULTS))."
                                                                (match-string 3 string))))
                                                      (split-string (car md-split) "\n" t " *"))
                                            nil))
-                            (kovids-magic "calibre-debug -c  \"from calibre.ebooks.metadata import *; import sys; print(author_to_author_sort(' '.join(sys.argv[1:])))\" '%s'")
+                            (kovids-magic (format
+                                           "%s -c  \"from calibre.ebooks.metadata import *; import sys; print(author_to_author_sort(' '.join(sys.argv[1:])))\" '%s'"
+                                           calibre-debug-program))
                             (author-sort (shell-command-to-string (format
                                                                    kovids-magic
                                                                    (intern (cdr (assoc "Authors" no-comments))))))


### PR DESCRIPTION
First I fixed some issues that occurred if no metadata was found. Second, I have
changed or added the completing-read options to ivy-read. Third I added
universal argument options to both the AUTHOR/TITLE and the ISBN search
functions. Fourth, I cleaned up redundant code and moreover I have split the
calibredb-fetch-metadata function for better readability. Finally, I have added
some doc strings.