### PR TITLE
Implement customize set or prompt fetch cover

### DIFF
--- a/calibredb-core.el
+++ b/calibredb-core.el
@@ -78,6 +78,11 @@
   :type 'string
   :group 'calibredb)
 
+(defcustom calibredb-fetch-covers nil
+  "Fetch cover when fetching metadata? (string \"yes\"/\"no\")."
+  :type 'string
+  :group 'calibredb)
+
 (defcustom calibredb-library-alist `((,calibredb-root-dir))
   "Alist for all your calibre libraries."
   :type 'alist

--- a/calibredb-search.el
+++ b/calibredb-search.el
@@ -359,8 +359,9 @@ Argument EVENT mouse event."
   "Quit *calibredb-entry* then *calibredb-search*."
   (interactive)
   (when (eq major-mode 'calibredb-search-mode)
-    (if (get-buffer "*calibredb-entry*")
-        (kill-buffer "*calibredb-entry*")
+    (cond ((get-buffer "*calibredb-entry*")
+           (switch-to-buffer "*calibredb-entry*")
+           (kill-buffer-and-window))
       (if (get-buffer "*calibredb-search*")
           (kill-buffer "*calibredb-search*")))))
 


### PR DESCRIPTION
Let the user decide if he wants to fetch cover. Skipping fetching the cover is faster. Again the variable is customizable, if customizable variable is not set than the user will be prompted before fetching metadata.

Should we implement a list of preferred order of metadata sources? Might be handy for bulk fetching metadata, although for me it has no priority.