### PR TITLE
Develop

### DIFF
--- a/calibredb-search.el
+++ b/calibredb-search.el
@@ -377,7 +377,7 @@ Argument EVENT mouse event."
   (interactive)
   (when (eq major-mode 'calibredb-search-mode)
     (cond ((get-buffer "*calibredb-entry*")
-           (delete-window (get-buffer-window "*calibredb-entry*")))
+           (kill-buffer "*calibredb-entry*"))
           ((get-buffer "*calibredb-search*")
            (kill-buffer "*calibredb-search*")))))
 

--- a/calibredb-search.el
+++ b/calibredb-search.el
@@ -360,10 +360,9 @@ Argument EVENT mouse event."
   (interactive)
   (when (eq major-mode 'calibredb-search-mode)
     (cond ((get-buffer "*calibredb-entry*")
-           (switch-to-buffer "*calibredb-entry*")
-           (kill-buffer-and-window))
-      (if (get-buffer "*calibredb-search*")
-          (kill-buffer "*calibredb-search*")))))
+           (delete-window (get-buffer-window "*calibredb-entry*")))
+          ((get-buffer "*calibredb-search*")
+           (kill-buffer "*calibredb-search*")))))
 
 (defun calibredb-mark-at-point ()
   "Mark the current line."

--- a/calibredb-search.el
+++ b/calibredb-search.el
@@ -359,8 +359,9 @@ Argument EVENT mouse event."
   "Quit *calibredb-entry* then *calibredb-search*."
   (interactive)
   (when (eq major-mode 'calibredb-search-mode)
-    (if (get-buffer "*calibredb-entry*")
-        (kill-buffer "*calibredb-entry*")
+    (cond ((get-buffer "*calibredb-entry*")
+           (switch-to-buffer "*calibredb-entry*")
+           (kill-buffer-and-window))
       (if (get-buffer "*calibredb-search*")
           (kill-buffer "*calibredb-search*")))))
 

--- a/calibredb-transient.el
+++ b/calibredb-transient.el
@@ -62,7 +62,8 @@
     ("r" "Refresh Library"   calibredb-search-refresh)]
    [("n" "Next Library"   calibredb-library-next)
     ("p" "Previous Library"   calibredb-library-previous)
-    ("t" "Toggle view (Compact/Detail)"   calibredb-toggle-view)]])
+    ("t" "Toggle view (Compact/Detail)"   calibredb-toggle-view)]]
+  [("q" "Quit"   transient-quit-one)])
 
 (define-transient-command calibredb-entry-dispatch ()
   "Invoke a calibredb command from a list of available commands in *calibredb-entry*."
@@ -76,7 +77,8 @@
     ("O" "Open file other frame"            calibredb-find-file-other-frame)
     ("V" "Open file with default tool"  calibredb-open-file-with-default-tool)
     ("." "Open dired"  calibredb-open-dired)]
-   [("e" "Export" calibredb-export-dispatch)]])
+   [("e" "Export" calibredb-export-dispatch)]]
+  [("q" "Quit"   transient-quit-one)])
 
 (define-transient-command calibredb-set-metadata-dispatch ()
   "Dispatch for set-metadata."
@@ -107,7 +109,8 @@
    ["Set metadata"
     ("s" "Set metadata"         calibredb-set-metadata--transient)
     ("f" "Fetch and set metadata by author and title"  calibredb-fetch-and-set-metadata-by-author-and-title)
-    ("i" "Fetch and set metadata by ISBN"  calibredb-fetch-and-set-metadata-by-isbn)]])
+    ("i" "Fetch and set metadata by ISBN"  calibredb-fetch-and-set-metadata-by-isbn)]]
+  [("q" "Quit"   transient-quit-one)])
 
 (define-transient-command calibredb-export-dispatch ()
   "Dispatch for export."
@@ -126,7 +129,8 @@
    ("-l" "Convert paths to lowercase." "--to-lowercase")
    ("-A" "Export all books in database, ignoring the list of ids" "--all")]
   [["Export"
-    ("e" "Export"         calibredb-export)]])
+    ("e" "Export"         calibredb-export)]]
+  [("q" "Quit"   transient-quit-one)])
 
 (define-transient-command calibredb-catalog-bib-dispatch ()
   "Dispatch for catalog BibTex."
@@ -141,7 +145,8 @@
    ("-E" "BibTeX file encoding flag. Default: strict"  "--choose-encoding-configuration " calibredb-transient-read-choose-encoding-configuration)]
   [["Bibtex"
     ("o" "Find BibTex file"         calibredb-find-bib)
-    ("b" "Update BibTex file"         calibredb-catalog-bib--transient)]])
+    ("b" "Update BibTex file"         calibredb-catalog-bib--transient)]]
+  [("q" "Quit"   transient-quit-one)])
 
 (defun calibredb-transient-read-bib-fields (prompt _initial-input _history)
   "TODO: Read a BibTex --fields value.

--- a/calibredb-utils.el
+++ b/calibredb-utils.el
@@ -47,8 +47,9 @@
 (declare-function pdf-info-search-string "pdf-info")
 (declare-function pdf-info-gettext "pdf-info")
 (declare-function djvu-find-file "djvu")
-(declare-function djvu-ref "djvu")
 (declare-function djvu-next-page "djvu")
+
+(defvar djvu-doc-page)
 
 ;;;###autoload
 (defun calibredb-list ()
@@ -491,11 +492,11 @@ Scan for isbn from page 1 upto (not including) END-PAGE (default 10) for pdf fil
 This function requires the djvu (djvu.el) package to be installed.
 Scan for isbn from the first 9 pages of the djvu file."
   (djvu-find-file (calibredb-getattr (car (calibredb-find-candidate-at-point)) :file-path))
-  (let* ((match (let ((page (djvu-ref page) )
+  (let* ((match (let ((page djvu-doc-page)
                       (match nil))
                   (while (not (or match (eq page 10)))
                     (djvu-next-page 1)
-                    (setq page (djvu-ref page) )
+                    (setq page djvu-doc-page)
                     (when (re-search-forward "^.*isbn.*$" nil t) (setq match t)))
                   (print match))))
     (let ((isbn-line ""))

--- a/calibredb-utils.el
+++ b/calibredb-utils.el
@@ -46,6 +46,11 @@
 (declare-function calibredb-set-metadata-arguments "calibredb-transient.el")
 (declare-function calibredb-export-arguments "calibredb-transient.el")
 (declare-function calibredb-catalog-bib-arguments "calibredb-transient.el")
+(declare-function pdf-info-search-string "pdf-info")
+(declare-function pdf-info-gettext "pdf-info")
+(declare-function djvu-find-file "djvu")
+(declare-function djvu-ref "djvu")
+(declare-function djvu-next-page "djvu")
 
 ;;;###autoload
 (defun calibredb-list ()


### PR DESCRIPTION
First, I have removed some boundp checks that should be redundant. The `fboundp first` is redundant because `first` is just an alias for `car`. The pdf and djvu boundp's should be redundant as there is already a pdf-tools and djvu `featurep` check in `calibredb-auto-detect-isbn` (I have also removed the interactive from the pdf and djvu isbn fetch functions, and added the requirement in the docstring).

Second I have removed the local page and doc variables from the calibredb-djvu-auto-detect-isbn function. The djvu-ref function somehow expecta an unquoted `page` symbol as an argument (open a djvu-file and try `M-: (djvu-ref page)`. Also it uses `doc` as default value if no second argument is passed.

Third, I have added x to the possible member's of the ISBN string (as it seems ISBN's sometimes contain x)