### PR TITLE
Fix two windows open when closing *calibredb-entry*

### DIFF
--- a/calibredb-search.el
+++ b/calibredb-search.el
@@ -401,7 +401,10 @@ Argument EVENT mouse event."
   (interactive)
   (when (eq major-mode 'calibredb-search-mode)
     (cond ((get-buffer "*calibredb-entry*")
-           (kill-buffer "*calibredb-entry*"))
+           (pop-to-buffer "*calibredb-entry*")
+           (if (< (length (window-prev-buffers)) 2)
+               (kill-buffer-and-window)
+             (kill-buffer)))
           ((get-buffer "*calibredb-search*")
            (kill-buffer "*calibredb-search*")))))
 


### PR DESCRIPTION
Hi again! I was still a little annoyed by the second window that stays open after closing the *calibre-entry* buffer.
(press `v` and immediately `q` from the *calibredb-search* and you will end up with two identical windows).
Now this is another fix that I think should work correct (it only deletes the calibredb-view window when no other buffers are in the prev-buffer list).