### PR TITLE
fetch metadata with identifier

### DIFF
--- a/calibredb-transient.el
+++ b/calibredb-transient.el
@@ -113,7 +113,8 @@
    ["Set metadata"
     ("s" "Set metadata With Arguments"         calibredb-set-metadata--transient)
     ("f" "Fetch and set metadata by author and title"  calibredb-fetch-and-set-metadata-by-author-and-title)
-    ("i" "Fetch and set metadata by ISBN"  calibredb-fetch-and-set-metadata-by-isbn)]]
+    ("i" "Fetch and set metadata by ISBN"  calibredb-fetch-and-set-metadata-by-isbn)
+    ("d" "Fetch and set metadata by identifier"  calibredb-fetch-and-set-metadata-by-id)]]
   [("q" "Quit"   transient-quit-one)])
 
 (transient-define-prefix calibredb-export-dispatch ()


### PR DESCRIPTION
This should allow you to search ebook metadata using identifiers. I tend to fill most of the fiction in my library with metadata from Goodreads. Currently only searches one identifier at a time; however that can be changed if desired.