### PR TITLE
Fix `calibredb-fetch-and-set-metadata-by-isbn` functionality

### DIFF
--- a/calibredb-utils.el
+++ b/calibredb-utils.el
@@ -745,10 +745,11 @@ Optional argument ARG."
                 ((string= type "author") (if arg (calibredb-fetch-metadata title authors)
                                            (calibredb-fetch-metadata authors title)))
                 ((string= type "isbn") (if arg
-                                           (calibredb-fetch-metadata authors title title)
+                                           (calibredb-fetch-metadata authors title nil title)
                                          (calibredb-fetch-metadata
                                           authors
                                           title
+                                          nil
                                           (cond ((calibredb-auto-detect-isbn))
                                                 (""))))))))
     (cond (metadata


### PR DESCRIPTION
It looks like a new argument for the `calibredb-fetch-metadata` function has been introduced, which broke the `calibredb-fetch-and-set-metadata-by-isbn` functionality. This PR passes `nil` for that new argument, which fixes the `calibredb-fetch-and-set-metadata-by-isbn` functionality.