### PR TITLE
Simplifying functions, fixing typos and add error handling in calibredb-query

### DIFF
--- a/calibredb-faces.el
+++ b/calibredb-faces.el
@@ -39,13 +39,13 @@
   "Face used for title on compact view."
   :group 'calibredb-faces)
 
-(defface calibredb-title-detail-view-face
+(defface calibredb-title-detailed-view-face
   '((((class color) (background light))
      :background "gray85")
     (((class color) (background dark))
      :background "gray25")
     (t :inherit calibredb-title-face))
-  "Face used for title on detail view."
+  "Face used for title on detailed view."
   :group 'calibredb-faces)
 
 (defface calibredb-author-face

--- a/calibredb-search.el
+++ b/calibredb-search.el
@@ -866,7 +866,6 @@ ARGUMENT FILTER is the filter string."
   (setq calibredb-detailed-view (if (eq calibredb-detailed-view nil) t nil))
   (calibredb-search-toggle-view-refresh))
 
-<<<<<<< HEAD
 (defun calibredb-detail-view-insert-image (entry)
   "Insert image in *calibredb-search* under detail view based on ENTRY."
   (if (and calibredb-detial-view calibredb-detial-view-image-show)
@@ -877,7 +876,7 @@ ARGUMENT FILTER is the filter string."
         (insert "\n")
         (insert (make-string num ? ))
         (calibredb-insert-image (calibredb-get-cover (cdr entry)) "" calibredb-detail-view-image-max-width calibredb-detail-view-image-max-height))))
-=======
+
 (defun calibredb-detailed-view-insert-image (entry)
   "Insert image in *calibredb-search* under detailed view based on ENTRY."
   (if (and calibredb-detailed-view calibredb-detailed-view-image-show)
@@ -897,7 +896,6 @@ ARGUMENT FILTER is the filter string."
               (insert "\n")
               (insert (make-string num ? ))
               (calibredb-insert-image cover "" calibredb-detailed-view-image-max-width calibredb-detailed-view-image-max-height))))))
->>>>>>> 4eaaa1f252031ab3d461b430b3f981543db14f68
 
 (defun calibredb-toggle-view-at-point ()
   "Toggle between detailed view or compact view in *calibredb-search* buffer at point."

--- a/calibredb-search.el
+++ b/calibredb-search.el
@@ -162,24 +162,27 @@ time."
 (define-obsolete-function-alias 'calibredb-search-ret
   'calibredb-view "calibredb 2.0.0")
 
-(defcustom calibredb-detial-view nil
+(defcustom calibredb-detailed-view nil
   "Set Non-nil to change detail view, nil to compact view - *calibredb-search*."
   :group 'calibredb
   :type 'boolean)
 
-(defcustom calibredb-detial-view-image-show t
-  "Set Non-nil to show images in detail view - *calibredb-search*."
+(define-obsolete-variable-alias 'calibredb-detial-view 'calibredb-detailed-view
+  "See https://github.com/chenyanming/calibredb.el/pull/45" "Fixing typos.")
+
+(defcustom calibredb-detailed-view-image-show t
+  "Set Non-nil to show images in detailed view - *calibredb-search*."
   :group 'calibredb
   :type 'boolean)
 
-(defcustom calibredb-detail-view-image-max-width 250
-  "Max Width for images in detail view - *calibredb-search*.
+(defcustom calibredb-detailed-view-image-max-width 250
+  "Max Width for images in detailed view - *calibredb-search*.
 For emacs 27.1+, if imagemagick is disabled, it would the image width."
   :group 'calibredb
   :type 'integer)
 
-(defcustom calibredb-detail-view-image-max-height 250
-  "Max height for images in detail view - *calibredb-search*.
+(defcustom calibredb-detailed-view-image-max-height 250
+  "Max height for images in detailed view - *calibredb-search*.
 For emacs 27.1+, if imagemagick is disabled, the image height is ignored."
   :group 'calibredb
   :type 'integer)
@@ -712,7 +715,7 @@ Argument KEYWORD is the metadata keyword to be toggled."
     (let ((content (car entry)) beg end)
       (setq beg (point))
       (insert content)
-      (calibredb-detail-view-insert-image entry)
+      (calibredb-detailed-view-insert-image entry)
       (setq end (point))
       (put-text-property beg end 'calibredb-entry entry))))
 
@@ -855,14 +858,15 @@ ARGUMENT FILTER is the filter string."
                  (push line res-list)))))
     (nreverse res-list)))
 
-;;; detail view
+;;; detailed view
 
 (defun calibredb-toggle-view ()
-  "Toggle between detail view or compact view in *calibredb-search* buffer."
+  "Toggle between detailed view or compact view in *calibredb-search* buffer."
   (interactive)
-  (setq calibredb-detial-view (if (eq calibredb-detial-view nil) t nil))
+  (setq calibredb-detailed-view (if (eq calibredb-detailed-view nil) t nil))
   (calibredb-search-toggle-view-refresh))
 
+<<<<<<< HEAD
 (defun calibredb-detail-view-insert-image (entry)
   "Insert image in *calibredb-search* under detail view based on ENTRY."
   (if (and calibredb-detial-view calibredb-detial-view-image-show)
@@ -873,18 +877,39 @@ ARGUMENT FILTER is the filter string."
         (insert "\n")
         (insert (make-string num ? ))
         (calibredb-insert-image (calibredb-get-cover (cdr entry)) "" calibredb-detail-view-image-max-width calibredb-detail-view-image-max-height))))
+=======
+(defun calibredb-detailed-view-insert-image (entry)
+  "Insert image in *calibredb-search* under detailed view based on ENTRY."
+  (if (and calibredb-detailed-view calibredb-detailed-view-image-show)
+      (let* ((num (cond (calibredb-format-all-the-icons 3)
+                        (calibredb-format-icons-in-terminal 3)
+                        ((>= calibredb-id-width 0) calibredb-id-width)
+                        (t 0 )))
+             (file (calibredb-getattr (cdr entry) :file-path))
+             (format (calibredb-getattr (cdr entry) :book-format))
+             (cover (concat (file-name-directory file) "cover.jpg")))
+          (if (image-type-available-p (intern format))
+              (progn
+                (insert "\n")
+                (insert (make-string num ? ))
+                (calibredb-insert-image file "" calibredb-detailed-view-image-max-width calibredb-detailed-view-image-max-height))
+            (progn
+              (insert "\n")
+              (insert (make-string num ? ))
+              (calibredb-insert-image cover "" calibredb-detailed-view-image-max-width calibredb-detailed-view-image-max-height))))))
+>>>>>>> 4eaaa1f252031ab3d461b430b3f981543db14f68
 
 (defun calibredb-toggle-view-at-point ()
-  "Toggle between detail view or compact view in *calibredb-search* buffer at point."
+  "Toggle between detailed view or compact view in *calibredb-search* buffer at point."
   (interactive)
   (let ((inhibit-read-only t)
-        (status calibredb-detial-view))
-    (if calibredb-detial-view
-        ;; detail view
+        (status calibredb-detailed-view))
+    (if calibredb-detailed-view
+        ;; detailed view
         (cond
          ;; save to calibredb-entry
          ((get-text-property (point) 'calibredb-entry nil)
-          (setq calibredb-detial-view nil)
+          (setq calibredb-detailed-view nil)
           (let* ((original (get-text-property (point) 'calibredb-entry nil))
                  (entry (cadr original))
                  (format (list (calibredb-format-item entry)))
@@ -911,11 +936,11 @@ ARGUMENT FILTER is the filter string."
                   (insert content)
                   (setq end (point))
                   (put-text-property beg end 'calibredb-compact list)))))
-          (setq calibredb-detial-view status))
+          (setq calibredb-detailed-view status))
 
          ;; save to calibredb-compact
          ((get-text-property (point) 'calibredb-compact nil)
-          (setq calibredb-detial-view t)
+          (setq calibredb-detailed-view t)
           (let* ((original (get-text-property (point) 'calibredb-compact nil))
                  (entry (cadr original))
                  (format (list (calibredb-format-item entry))))
@@ -927,16 +952,16 @@ ARGUMENT FILTER is the filter string."
                       beg end)
                   (setq beg (point))
                   (insert content)
-                  (calibredb-detail-view-insert-image original)
+                  (calibredb-detailed-view-insert-image original)
                   (setq end (point))
                   (put-text-property beg end 'calibredb-entry list)))))
-          (setq calibredb-detial-view status)))
+          (setq calibredb-detailed-view status)))
 
       ;; compact view
       (cond
        ;; save to calibredb-entry
        ((get-text-property (point) 'calibredb-entry nil)
-        (setq calibredb-detial-view t)
+        (setq calibredb-detailed-view t)
         (let* ((original (get-text-property (point) 'calibredb-entry nil))
                (entry (cadr original))
                (format (list (calibredb-format-item entry))))
@@ -948,26 +973,26 @@ ARGUMENT FILTER is the filter string."
                     beg end)
                 (setq beg (point))
                 (insert content)
-                (calibredb-detail-view-insert-image original)
+                (calibredb-detailed-view-insert-image original)
                 (setq end (point))
-                (put-text-property beg end 'calibredb-detail list)))))
-        (setq calibredb-detial-view status))
+                (put-text-property beg end 'calibredb-detailed list)))))
+        (setq calibredb-detailed-view status))
 
-       ;; save to calibredb-detail
-       ((get-text-property (point) 'calibredb-detail nil)
-        (setq calibredb-detial-view nil)
-        (let* ((original (get-text-property (point) 'calibredb-detail nil))
+       ;; save to calibredb-detailed
+       ((get-text-property (point) 'calibredb-detailed nil)
+        (setq calibredb-detailed-view nil)
+        (let* ((original (get-text-property (point) 'calibredb-detailed nil))
                (entry (cadr original))
                (format (list (calibredb-format-item entry)))
-               (id (calibredb-get-init "id" (cdr (get-text-property (point) 'calibredb-detail nil)))) ; the "id" of current point
+               (id (calibredb-get-init "id" (cdr (get-text-property (point) 'calibredb-detailed nil)))) ; the "id" of current point
                d-beg d-end)
-          (if (equal id (calibredb-get-init "id" (cdr (get-text-property (point-min) 'calibredb-detail nil))))
+          (if (equal id (calibredb-get-init "id" (cdr (get-text-property (point-min) 'calibredb-detailed nil))))
               (setq d-beg (point-min))
-            (save-excursion (while (equal id (calibredb-get-init "id" (cdr (get-text-property (point) 'calibredb-detail nil))))
+            (save-excursion (while (equal id (calibredb-get-init "id" (cdr (get-text-property (point) 'calibredb-detailed nil))))
                               (forward-line -1))
                             (forward-line 1)
                             (setq d-beg (point))))
-          (save-excursion (while (equal id (calibredb-get-init "id" (cdr (get-text-property (point) 'calibredb-detail nil))))
+          (save-excursion (while (equal id (calibredb-get-init "id" (cdr (get-text-property (point) 'calibredb-detailed nil))))
                             (forward-line 1))
                           (goto-char (1- (point)))
                           (setq d-end (point)))
@@ -981,7 +1006,7 @@ ARGUMENT FILTER is the filter string."
                 (insert content)
                 (setq end (point))
                 (put-text-property beg end 'calibredb-entry list)))))
-        (setq calibredb-detial-view status))))))
+        (setq calibredb-detailed-view status))))))
 
 (defun calibredb-fontify (string mode)
   "Fontify STRING with Major MODE."

--- a/calibredb-utils.el
+++ b/calibredb-utils.el
@@ -33,7 +33,7 @@
 (eval-when-compile (defvar calibredb-images-path))
 
 (declare-function calibredb-search-buffer "calibredb-search.el")
-(declare-function calibredb-detail-view-insert-image "calibredb-utils.el")
+(declare-function calibredb-detailed-view-insert-image "calibredb-utils.el")
 (declare-function calibredb-search-mode "calibredb-search.el")
 (declare-function calibredb-search--buffer-name "calibredb-search.el")
 (declare-function calibredb-counsel-add-file-action "calibredb-ivy.el")
@@ -322,14 +322,14 @@ With ivy-mode: Add marked items.
 Others: Add only one item.
 If prefix ARG is non-nil, keep the files after adding without prompt."
   (interactive "P")
-  (cond ((boundp 'ivy-mode)
-             (if ivy-mode
-                 (if (fboundp 'counsel--find-file-1)
-                     (counsel--find-file-1
-                      "Add file(s) to calibre: " calibredb-download-dir
-                      (lambda (file)
-                        (calibredb-counsel-add-file-action arg file))
-                      'calibredb-add))))
+  (cond ((and (boundp 'ivy-mode)
+              ivy-mode
+              (fboundp 'counsel--find-file-1))
+         (counsel--find-file-1
+          "Add file(s) to calibre: " calibredb-download-dir
+          (lambda (file)
+            (calibredb-counsel-add-file-action arg file))
+          'calibredb-add))
         (t (let ((file (read-file-name "Add a file to Calibre: " calibredb-download-dir)))
              (calibredb-counsel-add-file-action arg file))))
   (if (equal major-mode 'calibredb-search-mode)
@@ -580,7 +580,7 @@ Argument CANDS is the list of candiates."
   (interactive)
   (if (eq major-mode 'calibredb-search-mode)
       (list (cdr (or (get-text-property (point) 'calibredb-entry nil)
-                     (get-text-property (point) 'calibredb-detail nil)
+                     (get-text-property (point) 'calibredb-detailed nil)
                      (get-text-property (point) 'calibredb-compact nil))))
     (list (get-text-property (point-min) 'calibredb-entry nil) )))
 

--- a/calibredb.el
+++ b/calibredb.el
@@ -55,14 +55,15 @@
 (defun calibredb ()
   "Enter calibre Search Buffer."
   (interactive)
-  (let ((cand (if calibredb-search-entries
-                  calibredb-search-entries
-                (progn
-                  (setq calibredb-search-entries (calibredb-candidates))
-                  (setq calibredb-full-entries calibredb-search-entries)))))
-    (cond ((not cand)
-           (message "INVALID LIBRARY"))
-          (t
+  (cond ((null calibredb-db-dir)
+         (message "calibredb: calibredb-db-dir is nil! calibredb won't work without it."))
+        ((not (file-regular-p calibredb-db-dir))
+         (message "calibredb: %s doesn't exist!") calibredb-db-dir)
+        (t
+         (let ((cand (or calibredb-search-entries
+                         (setq calibredb-search-entries (calibredb-candidates)))))
+           (unless calibredb-full-entries
+             (setq calibredb-full-entries calibredb-search-entries))
            (when (get-buffer (calibredb-search-buffer))
              (kill-buffer (calibredb-search-buffer)))
            ;; Set virtual library name when the first time to launch calibredb
@@ -75,7 +76,7 @@
                (let (beg end)
                  (setq beg (point))
                  (insert (car item))
-                 (calibredb-detail-view-insert-image item)
+                 (calibredb-detailed-view-insert-image item)
                  (setq end (point))
                  (put-text-property beg end 'calibredb-entry item)
                  (insert "\n")))


### PR DESCRIPTION
The pull request from #45 is now based on the develop branch.

Also, you might have noticed that the number of commits in this pull request is _less_ than the last one, this is because I squashed minor commits together so that they are easier to read through.

And one last thing, in #45 I'd exclaimed that alists are not suitable for this package and that we should use plists or hash tables instead to fix speed issue, I take back my word. What I called "speed issue" is too broad to really carry any meaningful message, the "speed issue" of this package is actually from the time querying the sqlite database of calibre when there are a large amount of books, there is not much we can do about that, either some sql wizards can optimize the code in `calibredb-query-string` to cut down some time or somebody comes up with a new shell command to query the database in `calibredb-query` altogether. True, storing the queried entries in hash tables maybe slightly faster for live filter but, it doesn't help the load time or anything and the time refactoring the code and testing is too much for what is essentially a non-issue. (Or maybe not? I don't know, I don't have that many books in my calibre (< 100) do you experience slowness with live filter with many books?)

TLDR; Hash tables are not worth it.