### PR TITLE
Declare faces used by `calibredb-search-header`

### DIFF
--- a/calibredb-faces.el
+++ b/calibredb-faces.el
@@ -189,15 +189,15 @@
   :group 'calibredb-faces)
 
 (defface calibredb-search-header-sort-face '((t :inherit font-lock-keyword-face))
-  "Face used for sort field *calibredb-search* header."
+  "Face used for sort field in *calibredb-search* header."
   :group 'calibredb-faces)
 
 (defface calibredb-search-header-filter-face '((t :inherit font-lock-negation-char-face))
-  "Face used for filter field *calibredb-search* header."
+  "Face used for filter field in *calibredb-search* header."
   :group 'calibredb-faces)
 
 (defface calibredb-mouse-face '((t :inherit mode-line-highlight))
-  "Face used for *calibredb-search* mouse face"
+  "Face used for *calibredb-search* mouse face."
   :group 'calibredb-faces)
 
 (defface calibredb-edit-annotation-header-title-face
@@ -206,7 +206,7 @@
     (((class color) (background dark))
      :foreground "#A3BE8C")
     (t :inherit default))
-  "Face used for *calibredb-edit-annotation* header tilte face"
+  "Face used for *calibredb-edit-annotation* header title face."
   :group 'calibredb-faces)
 
 (provide 'calibredb-faces)

--- a/calibredb-faces.el
+++ b/calibredb-faces.el
@@ -176,6 +176,26 @@
   "Face used for archive."
   :group 'calibredb-faces)
 
+(defface calibredb-search-header-library-name-face '((t :inherit font-lock-preprocessor-face))
+  "Face used for library name in *calibredb-search* header."
+  :group 'calibredb-faces)
+
+(defface calibredb-search-header-library-path-face '((t :inherit font-lock-type-face))
+  "Face used for library path in *calibredb-search* header."
+  :group 'calibredb-faces)
+
+(defface calibredb-search-header-total-face '((t :inherit font-lock-warning-face))
+  "Face used for total count in *calibredb-search* header."
+  :group 'calibredb-faces)
+
+(defface calibredb-search-header-sort-face '((t :inherit font-lock-keyword-face))
+  "Face used for sort field *calibredb-search* header."
+  :group 'calibredb-faces)
+
+(defface calibredb-search-header-filter-face '((t :inherit font-lock-negation-char-face))
+  "Face used for filter field *calibredb-search* header."
+  :group 'calibredb-faces)
+
 (defface calibredb-mouse-face '((t :inherit mode-line-highlight))
   "Face used for *calibredb-search* mouse face"
   :group 'calibredb-faces)

--- a/calibredb-search.el
+++ b/calibredb-search.el
@@ -344,13 +344,13 @@ Optional argument SWITCH to switch to *calibredb-search* buffer to other window.
   "TODO: Return the string to be used as the Calibredb header.
 Indicating the library you use."
   (format "%s: %s   %s"
-          (propertize calibredb-virtual-library-name 'face font-lock-preprocessor-face)
-          (propertize calibredb-root-dir 'face font-lock-type-face)
+          (propertize calibredb-virtual-library-name 'face 'calibredb-search-title-library-name-face)
+          (propertize calibredb-root-dir 'face 'calibredb-search-title-library-path-face)
           (concat
            (propertize (format "Total: %s"
                                (if (equal calibredb-search-entries '(""))
                                    "0   "
-                                 (concat (number-to-string (length calibredb-search-entries)) "  "))) 'face font-lock-warning-face)
+                                 (concat (number-to-string (length calibredb-search-entries)) "  "))) 'face 'calibredb-search-title-total-face)
            (cond ((eq calibredb-sort-by 'id)
                   "Sort: id ")
                  ((eq calibredb-sort-by 'title)
@@ -386,10 +386,10 @@ Indicating the library you use."
                                 (t ""))
                                (if (equal calibredb-search-filter "")
                                    ""
-                                 (concat calibredb-search-filter "   "))) 'face font-lock-keyword-face)
+                                 (concat calibredb-search-filter "   "))) 'face 'calibredb-search-title-sort-face)
            (propertize (let ((len (length (calibredb-find-marked-candidates))))
                          (if (> len 0)
-                             (concat "Marked: " (number-to-string len)) "")) 'face font-lock-negation-char-face))))
+                             (concat "Marked: " (number-to-string len)) "")) 'face 'calibredb-search-title-filter-face))))
 
 (define-derived-mode calibredb-search-mode fundamental-mode "calibredb-search"
   "Major mode for listing calibre entries.


### PR DESCRIPTION
This PR adds 5 new faces that `calibredb-search-header` function will use
instead of hardcoding them.

I also fixed a typo and a missing period in docstrings of two faces that I
noticed.