### PR TITLE
Fix opds link prediction.

### DIFF
--- a/calibredb-library.el
+++ b/calibredb-library.el
@@ -81,7 +81,7 @@ selecting the new item."
     (setq calibredb-virtual-library-default-name library-name)
     (setq calibredb-virtual-library-name calibredb-virtual-library-default-name)
     (cond
-     ((s-contains? "http" result)
+     ((string-prefix-p "http" result)
       (let ((library (-first (lambda (lib)
                                (s-contains? (car lib) result))
                              calibredb-library-alist)))
@@ -123,7 +123,7 @@ selecting the new item."
     (setq calibredb-virtual-library-default-name library-name)
     (setq calibredb-virtual-library-name calibredb-virtual-library-default-name)
     (cond
-     ((s-contains? "http" result)
+     ((string-prefix-p "http" result)
       (let ((library (-first (lambda (lib)
                                (s-contains? (car lib) result))
                              calibredb-library-alist)))
@@ -164,7 +164,7 @@ selecting the new item."
     (setq calibredb-virtual-library-default-name library-name)
     (setq calibredb-virtual-library-name calibredb-virtual-library-default-name)
     (cond
-     ((s-contains? "http" result)
+     ((string-prefix-p "http" result)
       (let ((library (-first (lambda (lib)
                                (s-contains? (car lib) result))
                              calibredb-library-alist)))

--- a/calibredb-opds.el
+++ b/calibredb-opds.el
@@ -178,7 +178,7 @@ Optional argument PASSWORD."
                   (:author-sort            ,(dom-text (esxml-query "author>name" entry))) ; TODO: support mutitple authors
                   (:book-dir               "")
                   (:book-cover             ,(let ((url (or (dom-attr (esxml-query "[type^=image]" entry) 'href) "")))
-                                              (if (and (stringp url) (s-contains? "http" url))
+                                              (if (and (stringp url) (string-prefix-p "http" url))
                                                   url
                                                 (cond ((s-equals-p "" url) nil) ; no image url, return nil
                                                       ((s-contains? "base64" url) url) ; base64 image
@@ -189,7 +189,7 @@ Optional argument PASSWORD."
                                                           (esxml-query "published" entry))))
                   (:book-title             ,(dom-text (esxml-query "title" entry)))
                   (:file-path              ,(let ((url (or (dom-attr (esxml-query "[type^=application]" entry) 'href) "")))
-                                              (if (and (stringp url) (s-contains? "http" url))
+                                              (if (and (stringp url) (string-prefix-p "http" url))
                                                   url
                                                 (cond ((s-equals-p "" url) "")
                                                       ((s-equals-p (s-left 1 url) "/") (format "%s%s" (calibredb-opds-host) url))

--- a/calibredb-search.el
+++ b/calibredb-search.el
@@ -265,7 +265,7 @@ Optional argument SWITCH to switch to *calibredb-search* buffer to other window.
                                                     (propertize ext
                                                                 'face 'calibredb-format-face
                                                                 'mouse-face 'calibredb-mouse-face
-                                                                'help-echo (if (s-contains? "http" file)
+                                                                'help-echo (if (string-prefix-p "http" file)
                                                                                file
                                                                              (expand-file-name
                                                                               (concat (file-name-base file) "." ext)
@@ -812,7 +812,7 @@ ebook record will be shown.
   "Update the calibredb-search buffer by library type, opds, metadata or
 folder meatadata."
   (cond
-   ((s-contains? "http" calibredb-root-dir)
+   ((string-prefix-p "http" calibredb-root-dir)
     (message "OPDS does not suppprt search at this moment."))
    ((and (stringp calibredb-db-dir)
          (file-exists-p calibredb-db-dir)

--- a/calibredb-utils.el
+++ b/calibredb-utils.el
@@ -127,7 +127,7 @@ Optional argument PROMPT to Select a format."
     (cond ((s-equals? "" file-path) "")         ; no file-path field
           ((file-exists-p file-path) file-path) ; default file-path is a valid file
           ((calibredb-local-file-exists-p entry) (calibredb-local-file entry)) ; valid local file is found
-          ((s-contains? "http" file-path) file-path) ; for http link, just return
+          ((string-prefix-p "http" file-path) file-path) ; for http link, just return
           (t (if (s-contains? "," (file-name-extension file-path)) ; try to split the extension (for example, it may be epub,pdf) and return the first format
                  (let* ((parent (file-name-directory file-path))
                         (filename (file-name-base file-path))
@@ -209,7 +209,7 @@ Download it if book-cover is non-nil."
 (defun calibredb-extract-cover (entry)
   "Extract ENTRY and save the cover to the same directory."
   ;; only extract cover if calibredb-root-dir is not a http link
-  (unless (s-contains? "http" calibredb-root-dir)
+  (unless (string-prefix-p "http" calibredb-root-dir)
     ;; only extract cover if ebook-meta is available
     (when (executable-find calibredb-ebook-meta-program)
       ;; extract cover
@@ -262,7 +262,7 @@ Optional argument CANDIDATE is the selected item."
                   (let ((calibredb-preferred-format nil))
                     (calibredb-get-file-path candidate t))
                 (calibredb-get-file-path candidate t))))
-    (cond ((s-contains? "http" file)
+    (cond ((string-prefix-p "http" file)
            (let ((url (calibredb-getattr candidate :file-path))
                  (title (calibredb-getattr candidate :book-title))
                  (type (calibredb-getattr candidate :book-format)))

--- a/calibredb.el
+++ b/calibredb.el
@@ -68,7 +68,7 @@
     (setq calibredb-virtual-library-name calibredb-virtual-library-default-name))
   (cond
    ;; opds
-   ((s-contains? "http" calibredb-root-dir)
+   ((string-prefix-p "http" calibredb-root-dir)
     (switch-to-buffer (calibredb-search-buffer))
     (goto-char (point-min))
     (calibredb-ref-default-bibliography)


### PR DESCRIPTION
When use a path like "/home/httpd/calibre-lib" as a local calibre lib
path, calibredb uses it as an OPDS link, which is not intended.